### PR TITLE
Added figure option to include all filters for order 1 and 2

### DIFF
--- a/nircam_jdox/nircam_grism_time_series/figure2_grism_throughput_order1.ipynb
+++ b/nircam_jdox/nircam_grism_time_series/figure2_grism_throughput_order1.ipynb
@@ -164,6 +164,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Figure option 2: all filters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm = pylab.get_cmap('tab10')\n",
+    "\n",
+    "f, ax1 = plt.subplots(1, figsize=(15, 10))\n",
+    "\n",
+    "\n",
+    "for i,fil in zip(range(NUM_COLORS),filters):\n",
+    "    color = cm(1.*i/NUM_COLORS)    \n",
+    "    \n",
+    "    if NRC_plus_OTE:\n",
+    "\n",
+    "        wav, thpt = np.loadtxt(datadir+fil+'_NRC_and_OTE_ModAB_mean.txt', unpack=True, skiprows=1)\n",
+    "        data = S.ArrayBandpass(wav, thpt, name=fil)\n",
+    "\n",
+    "    else:\n",
+    "\n",
+    "        data = S.FileBandpass(datadir+'jwst_nircam_'+fil.lower()+'_moda_trans.fits')\n",
+    "    \n",
+    "    maxval = 0.003\n",
+    "    ax1.plot(data.wave[data.throughput > maxval],data.throughput[data.throughput > maxval],lw=3,label=fil,color=color)\n",
+    "\n",
+    "ax1.text(4.7, 0.47, 'LW B grism',color='black',alpha=0.65,fontsize=20)        \n",
+    "ax1.text(4.7, 0.63, 'LW A grism',color='black',fontsize=20)        \n",
+    "\n",
+    "ax1.plot(blaze_w,modAm1,lw=2,color='black',marker='o',markersize=7)\n",
+    "ax1.plot(blaze_w,modBm1,lw=2,color='grey',marker='d',markersize=7)\n",
+    "\n",
+    "miny,maxy = ax1.get_ylim()\n",
+    "minx,maxx = ax1.get_xlim()\n",
+    "ax1.legend(bbox_to_anchor=(1., 1.013),fontsize=15)\n",
+    "ax1.tick_params(labelsize=18)\n",
+    "f.text(0.5, 0.04, 'Wavelength ($\\mu m$)', ha='center', fontsize=22)\n",
+    "f.text(0.05, 0.5, 'Throughput', va='center', rotation='vertical', fontsize=22)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Issues"
    ]
   },

--- a/nircam_jdox/nircam_grism_time_series/figure3_grism_throughput_order2.ipynb
+++ b/nircam_jdox/nircam_grism_time_series/figure3_grism_throughput_order2.ipynb
@@ -165,6 +165,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Figure option 2: all filters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_COLORS = len(filters)\n",
+    "\n",
+    "cm = pylab.get_cmap('tab10')\n",
+    "\n",
+    "f, ax1 = plt.subplots(1, figsize=(15, 10))\n",
+    "\n",
+    "\n",
+    "for i,fil in zip(range(NUM_COLORS),filters):\n",
+    "    color = cm(1.*i/NUM_COLORS)    \n",
+    "    \n",
+    "    if NRC_plus_OTE:\n",
+    "\n",
+    "        wav, thpt = np.loadtxt(datadir+fil+'_NRC_and_OTE_ModAB_mean.txt', unpack=True, skiprows=1)\n",
+    "        data = S.ArrayBandpass(wav, thpt, name=fil)\n",
+    "\n",
+    "    else:\n",
+    "\n",
+    "        data = S.FileBandpass(datadir+'jwst_nircam_'+fil.lower()+'_moda_trans.fits')\n",
+    "    \n",
+    "    maxval = 0.003\n",
+    "    ax1.plot(data.wave[data.throughput > maxval],data.throughput[data.throughput > maxval],lw=3,label=fil,color=color)\n",
+    "\n",
+    "ax1.text(1.94, 0.3, 'LW B grism',color='black',alpha=0.65,fontsize=20)        \n",
+    "ax1.text(1.94, 0.37, 'LW A grism',color='black',fontsize=20)        \n",
+    "\n",
+    "ax1.plot(blaze_w,modAm2,color='black',marker='s',markersize=7)\n",
+    "ax1.plot(blaze_w,modBm2,color='grey',marker='<',markersize=7)\n",
+    "\n",
+    "miny,maxy = ax1.get_ylim()\n",
+    "minx,maxx = ax1.get_xlim()\n",
+    "ax1.legend(bbox_to_anchor=(1., 1.013),fontsize=15)\n",
+    "ax1.set_xlim(minx-0.34,maxx-0.09)\n",
+    "ax1.tick_params(labelsize=18)\n",
+    "f.text(0.5, 0.04, 'Wavelength ($\\mu m$)', ha='center', fontsize=22)\n",
+    "f.text(0.05, 0.5, 'Throughput', va='center', rotation='vertical', fontsize=22)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Issues"
    ]
   },


### PR DESCRIPTION
## Description

Added figure option for grism throughput plots to include all filters for order 1 and 2. 

## How Has This Been Tested?

Notebooks were executed without errors and the outputs were cleared. 